### PR TITLE
Add program embedding wrapper

### DIFF
--- a/azr/__init__.py
+++ b/azr/__init__.py
@@ -1,0 +1,1 @@
+from .embeddings import ProgramEmbedder

--- a/azr/embeddings.py
+++ b/azr/embeddings.py
@@ -1,0 +1,17 @@
+from sentence_transformers import SentenceTransformer
+import torch
+
+class ProgramEmbedder:
+    def __init__(self, ckpt: str = "Salesforce/codet5p-110m-embedding"):
+        self.model = SentenceTransformer(ckpt, device="cuda")
+
+    @torch.no_grad()
+    def encode(self, code_str: str) -> torch.Tensor:
+        """Return 128-dim normalized embedding for provided code."""
+        v = self.model.encode([code_str], normalize_embeddings=True)[0]
+        return torch.tensor(v, dtype=torch.float16)[:128]
+
+if __name__ == "__main__":
+    emb = ProgramEmbedder()
+    vec = emb.encode("def add(a,b): return a+b")
+    print(vec.reshape(1, -1))

--- a/requirements.txt
+++ b/requirements.txt
@@ -198,3 +198,4 @@ xformers==0.0.28.post3
 xgrammar==0.1.11
 xxhash==3.5.0
 yarl==1.18.3
+sentence-transformers==2.7.0


### PR DESCRIPTION
## Summary
- add a new `azr` package with a `ProgramEmbedder` class
- allow embedding extraction and example run
- require `sentence-transformers`

## Testing
- `python -m azr.embeddings` *(fails: `ModuleNotFoundError: No module named 'sentence_transformers'`)*
